### PR TITLE
Warn user if they use tools with a chat_template that would not use them.

### DIFF
--- a/mistralrs-core/src/pipeline/chat_template.rs
+++ b/mistralrs-core/src/pipeline/chat_template.rs
@@ -4,10 +4,10 @@ use anyhow::Result;
 use either::Either;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use minijinja::{context, value::Kwargs, Environment, Error, ErrorKind, Value};
+use minijinja::{context, value::Kwargs, Environment, Error, ErrorKind, Template, Value};
 use serde::{Deserialize, Serialize};
 use tokenizers::Tokenizer;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{MessageContent, Tool};
 
@@ -264,8 +264,10 @@ pub fn apply_chat_template_to(
     };
 
     env.add_template("chat_template", &template)?;
+
     env.add_function("raise_exception", raise_exception);
     env.add_filter("tojson", tojson);
+
     let tmpl = env.get_template("chat_template").unwrap();
 
     let date = chrono::Utc::now();
@@ -281,6 +283,9 @@ pub fn apply_chat_template_to(
             date_string => date_string,
         })?)
     } else {
+        if !tools_are_supported(&tmpl) {
+            warn!("tools were provided to a 'chat_template' that does not support them. Tools will be ignored...");
+        }
         Ok(tmpl.render(context! {
             messages => new_messages,
             add_generation_prompt => add_generation_prompt,
@@ -291,4 +296,8 @@ pub fn apply_chat_template_to(
             date_string => date_string,
         })?)
     }
+}
+
+fn tools_are_supported(t: &Template) -> bool {
+    t.undeclared_variables(true).contains("tools")
 }


### PR DESCRIPTION
## 🗣 Description
 - Some chat templates used by models do not use tools when templating the string provided to the LLM. When tools are provided, they would be ignored. This PR preemptively warns if this occurs so users can understand why tools aren't being called. 
