### PR TITLE
Handle Sigterm from blocking HF model download.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,6 +2391,7 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "serde_yaml",
+ "signal-hook",
  "strum",
  "sysinfo",
  "thiserror 1.0.69",

--- a/mistralrs-core/Cargo.toml
+++ b/mistralrs-core/Cargo.toml
@@ -14,6 +14,7 @@ homepage.workspace = true
 [dependencies]
 candle-flash-attn = { git = "https://github.com/spiceai/candle.git", version = "0.8.0", rev = "296f14fefc8166574d3270c524494c49d8f2c893", optional = true }
 dirs = "5.0.1"
+signal-hook = "0.3.17"
 anyhow.workspace = true
 candle-core.workspace = true
 candle-nn.workspace = true

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -45,7 +45,7 @@ use crate::{
 use anyhow::{bail, Result};
 use candle_core::{Device, Tensor};
 use either::Either;
-use hf_hub::{api::sync::ApiBuilder, Repo, RepoType};
+use hf_hub::{api::tokio::ApiBuilder, Repo, RepoType};
 use mistralrs_quant::IsqType;
 use rand_isaac::Isaac64Rng;
 use std::any::Any;

--- a/mistralrs-core/src/pipeline/macros.rs
+++ b/mistralrs-core/src/pipeline/macros.rs
@@ -91,7 +91,7 @@ macro_rules! get_paths {
             &$token_source,
             $quantized_model_id.as_deref(),
             $quantized_filename,
-            &api,
+            api,
             &model_id,
             $loading_uqff,
         )?;
@@ -271,7 +271,7 @@ macro_rules! get_paths_gguf {
             &$token_source,
             Some($quantized_model_id.as_str()),
             Some($quantized_filenames),
-            &api,
+            api,
             &model_id,
             false, // Never loading UQFF
         )?;


### PR DESCRIPTION
## 🗣 Description
- This repo uses `hf_hub::api::sync::Api`  rather than `hf_hub::api::tokio::Api`. This means file downloads are blocking and don't by default handle SIGTERM and related signals well. This is a short term fix for this.

## 🔨 Related Issues
 - Branch [jeadie/25-02-16/sigterm-tokio](https://github.com/spiceai/mistral.rs/tree/jeadie/25-02-16/sigterm-tokio) is the initial work on using `hf_hub::api::tokio::Api` instead. 
