### PR TITLE
Bump candle rev to 7de0d9fd (picks up moe_gemm_wmma rename to avoid symbol collision)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ license = "MIT"
 rust-version = "1.88"
 
 [workspace.dependencies]
-candle-core = { git = "https://github.com/spiceai/candle.git", rev = "fab4da8172a997bc6dfb4100a51a72d1a7a37988" }
-candle-nn = { git = "https://github.com/spiceai/candle.git", rev = "fab4da8172a997bc6dfb4100a51a72d1a7a37988" }
-candle-flash-attn-v3 = { git = "https://github.com/spiceai/candle.git", rev = "fab4da8172a997bc6dfb4100a51a72d1a7a37988" }
-candle-flash-attn = { git = "https://github.com/spiceai/candle.git", rev = "fab4da8172a997bc6dfb4100a51a72d1a7a37988" }
-candle-metal-kernels = { git = "https://github.com/spiceai/candle.git", rev = "fab4da8172a997bc6dfb4100a51a72d1a7a37988" }
+candle-core = { git = "https://github.com/spiceai/candle.git", rev = "7de0d9fdff7dfb6289442abfba821e8d77f57c58" }
+candle-nn = { git = "https://github.com/spiceai/candle.git", rev = "7de0d9fdff7dfb6289442abfba821e8d77f57c58" }
+candle-flash-attn-v3 = { git = "https://github.com/spiceai/candle.git", rev = "7de0d9fdff7dfb6289442abfba821e8d77f57c58" }
+candle-flash-attn = { git = "https://github.com/spiceai/candle.git", rev = "7de0d9fdff7dfb6289442abfba821e8d77f57c58" }
+candle-metal-kernels = { git = "https://github.com/spiceai/candle.git", rev = "7de0d9fdff7dfb6289442abfba821e8d77f57c58" }
 # candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.3", rev = "88ed791" }
 # candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.3", rev = "88ed791" }
 # candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.3", rev = "88ed791" }


### PR DESCRIPTION
## Summary

Bumps the workspace `candle` rev from `fab4da81` to `7de0d9fd` to pick up [spiceai/candle#13](https://github.com/spiceai/candle/pull/13), which renames candle-kernels' `moe_gemm_wmma` → `candle_moe_gemm_wmma`.

## Why

candle-kernels and mistralrs-core each independently ship an `extern "C" void moe_gemm_wmma` kernel (both adapted from [guoqingbao/attention.rs](https://github.com/guoqingbao/attention.rs) but with diverged signatures and implementations). When both crates are linked into the same binary — e.g. `spiced --features cuda,models` — the static archives collide:

```
ld.lld: error: duplicate symbol: moe_gemm_wmma
  >>> defined in libmoe.a (from candle-kernels)
  >>> defined in libmistralrscuda.a (from mistralrs-core)
```

Renaming the **candle** side is the minimum-risk fix (3 mechanical edits, no semantic change). mistralrs-core keeps its `moe_gemm_wmma` / `moe_gemm_wmma_transposed` call sites untouched.

## Scope

- Only `Cargo.toml`: 5 candle crate revs bumped in lock-step.
- No mistralrs-core source changes needed — our own kernel and its callers are unaffected.

## Verification

Verified `spiced --features cuda,models` links cleanly on CUDA 12.6 / sm_90 (H100) with the matching spiceai/spiceai pin bump.