### PR TITLE
fix(gemma): make attention_bias optional in gemma/gemma2 configs

### DIFF
--- a/mistralrs-core/src/models/gemma.rs
+++ b/mistralrs-core/src/models/gemma.rs
@@ -33,9 +33,14 @@ fn default_max_position_embeddings() -> usize {
 }
 
 serde_default_fn!(bool, word_emb_default, false);
+serde_default_fn!(bool, attention_bias_default, false);
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Clone, Default)]
 pub struct Config {
+    // Gemma 2/3 HuggingFace configs sometimes omit `attention_bias` entirely
+    // (it implicitly defaults to `false`). Make this field optional so loading
+    // does not fail on those configs.
+    #[serde(default = "attention_bias_default")]
     pub attention_bias: bool,
     pub head_dim: usize,
     // The code gemma configs include both hidden_act and hidden_activation.

--- a/mistralrs-core/src/models/gemma2.rs
+++ b/mistralrs-core/src/models/gemma2.rs
@@ -29,9 +29,14 @@ use crate::{
 };
 
 serde_default_fn!(bool, word_emb_default, false);
+serde_default_fn!(bool, attention_bias_default, false);
 
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 pub struct Config {
+    // Gemma 2/3 HuggingFace configs sometimes omit `attention_bias` entirely
+    // (it implicitly defaults to `false`). Make this field optional so loading
+    // does not fail on those configs.
+    #[serde(default = "attention_bias_default")]
     pub attention_bias: bool,
     pub head_dim: usize,
     // The code gemma configs include both hidden_act and hidden_activation.


### PR DESCRIPTION
## Summary

The `attention_bias` field is omitted from many HuggingFace Gemma model configs (e.g. `google/gemma-2-2b-it`), causing model loading to fail with:

```
missing field `attention_bias` at line 197 column 1
```

Both `models::gemma::Config` and `models::gemma2::Config` declared `pub attention_bias: bool` without a serde default. This PR makes the field optional with a default of `false`, mirroring the pattern already used in `vision_models::gemma3::config::Gemma3TextConfig`.

## Changes

- `mistralrs-core/src/models/gemma.rs`: add `serde_default_fn!(bool, attention_bias_default, false);` and `#[serde(default = "attention_bias_default")]` on `Config::attention_bias`.
- `mistralrs-core/src/models/gemma2.rs`: same change.

## Verification

- `cargo check -p mistralrs-core` passes locally.
- Downstream spice runtime (`cargo check -p llms --features local_llm`) builds cleanly against this revision.