### PR TITLE
Fixes for gemma4

### DIFF
--- a/mistralrs-core/src/vision_models/gemma4/config.rs
+++ b/mistralrs-core/src/vision_models/gemma4/config.rs
@@ -79,7 +79,8 @@ pub struct Gemma4TextConfig {
     pub tie_word_embeddings: bool,
     #[serde(default = "sliding_window_pattern", alias = "_sliding_window_pattern")]
     pub sliding_window_pattern: usize,
-    pub layer_types: Vec<String>,
+    #[serde(default)]
+    pub layer_types: Option<Vec<String>>,
     #[serde(default = "global_head_dim")]
     pub global_head_dim: usize,
     #[serde(default = "attention_k_eq_v")]
@@ -102,6 +103,23 @@ pub struct Gemma4TextConfig {
 }
 
 impl Gemma4TextConfig {
+    /// Returns layer types, computing from `sliding_window_pattern` when absent from config.
+    /// Gemma 3 configs omit `layer_types` and use `sliding_window_pattern` instead.
+    pub fn effective_layer_types(&self) -> Vec<String> {
+        self.layer_types.clone().unwrap_or_else(|| {
+            (0..self.num_hidden_layers)
+                .map(|i| {
+                    if (i + 1) % self.sliding_window_pattern == 0 {
+                        "full_attention"
+                    } else {
+                        "sliding_attention"
+                    }
+                    .to_string()
+                })
+                .collect()
+        })
+    }
+
     /// Effective sliding window size, adjusted for bidirectional attention.
     /// `self.sliding_window = (self.sliding_window // 2) + 1` only when `use_bidirectional_attention == "all"`.
     pub fn effective_sliding_window(&self) -> usize {

--- a/mistralrs-core/src/vision_models/gemma4/config.rs
+++ b/mistralrs-core/src/vision_models/gemma4/config.rs
@@ -147,6 +147,50 @@ impl Gemma4TextConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_text_config(num_hidden_layers: usize, sliding_window_pattern: usize) -> Gemma4TextConfig {
+        serde_json::from_str(&format!(
+            r#"{{"hidden_size":3072,"intermediate_size":8192,"num_hidden_layers":{num_hidden_layers},"sliding_window":1024,"sliding_window_pattern":{sliding_window_pattern}}}"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn effective_layer_types_explicit() {
+        let explicit = vec!["full_attention".to_string(), "sliding_attention".to_string()];
+        let mut cfg = minimal_text_config(2, 6);
+        cfg.layer_types = Some(explicit.clone());
+        assert_eq!(cfg.effective_layer_types(), explicit);
+    }
+
+    #[test]
+    fn effective_layer_types_computed_from_pattern() {
+        // sliding_window_pattern=6: every 6th layer (1-indexed) is full_attention
+        let cfg = minimal_text_config(12, 6);
+        assert!(cfg.layer_types.is_none());
+        let types = cfg.effective_layer_types();
+        assert_eq!(types.len(), 12);
+        for (i, ty) in types.iter().enumerate() {
+            if (i + 1) % 6 == 0 {
+                assert_eq!(ty, "full_attention", "layer {i} should be full_attention");
+            } else {
+                assert_eq!(ty, "sliding_attention", "layer {i} should be sliding_attention");
+            }
+        }
+    }
+
+    #[test]
+    fn effective_layer_types_pattern_1_all_full() {
+        // sliding_window_pattern=1: every layer is full_attention
+        let cfg = minimal_text_config(4, 1);
+        let types = cfg.effective_layer_types();
+        assert!(types.iter().all(|t| t == "full_attention"));
+    }
+}
+
 // ── Vision config defaults ──────────────────────────────────────────────────
 
 serde_default_fn!(usize, vision_hidden_size, 768);

--- a/mistralrs-core/src/vision_models/gemma4/text.rs
+++ b/mistralrs-core/src/vision_models/gemma4/text.rs
@@ -36,7 +36,7 @@ use super::config::Gemma4TextConfig;
 
 macro_rules! is_sliding {
     ($layer_idx:expr, $cfg:expr) => {
-        $cfg.layer_types[$layer_idx] == "sliding_attention"
+        $cfg.effective_layer_types()[$layer_idx] == "sliding_attention"
     };
 }
 
@@ -51,8 +51,9 @@ fn kv_shared_layer_index(cfg: &Gemma4TextConfig, layer_idx: usize) -> Result<Opt
         return Ok(None);
     }
 
-    let attention_type = &cfg.layer_types[layer_idx];
-    cfg.layer_types[..first_kv_shared_layer_idx]
+    let layer_types = cfg.effective_layer_types();
+    let attention_type = &layer_types[layer_idx];
+    layer_types[..first_kv_shared_layer_idx]
         .iter()
         .rposition(|ty| ty == attention_type)
         .map(Some)
@@ -1284,9 +1285,10 @@ impl TextModel {
         let first_shared = first_kv_shared_layer_idx(cfg);
         let mut donor_layers = std::collections::HashSet::<usize>::new();
         if first_shared < cfg.num_hidden_layers {
+            let layer_types = cfg.effective_layer_types();
             for shared_idx in first_shared..cfg.num_hidden_layers {
-                let attention_type = &cfg.layer_types[shared_idx];
-                if let Some(donor_idx) = cfg.layer_types[..first_shared]
+                let attention_type = &layer_types[shared_idx];
+                if let Some(donor_idx) = layer_types[..first_shared]
                     .iter()
                     .rposition(|ty| ty == attention_type)
                 {

--- a/mistralrs-server-core/src/lib.rs
+++ b/mistralrs-server-core/src/lib.rs
@@ -163,7 +163,7 @@
 //!     let (tx, mut rx) = create_response_channel(None);
 //!
 //!     let (request, is_streaming) =
-//!         match parse_request(oai_request, mistralrs_state.clone(), tx).await {
+//!         match parse_request(oai_request, mistralrs_state.clone(), tx, None).await {
 //!             Ok(x) => x,
 //!             Err(e) => return handle_error(mistralrs_state, e.into()),
 //!         };


### PR DESCRIPTION
## 🗣 Description

The Gemma 4 model loader required `layer_types` in the config JSON, but Gemma 3 models don't include that field — they use `sliding_window_pattern` instead to describe which layers use sliding vs full attention. This caused an immediate crash when trying to load any Gemma 3 model through the Gemma 4 loader.                                                                                        
                                                                                                    
The fix makes `layer_types` optional and adds a fallback that computes the per-layer attention types from `sliding_window_pattern` when the field is missing.

Verified locally.