### PR TITLE
feat(gguf): GLM-MoE (glm-dsa) support + i-quant MoE fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 [[package]]
 name = "candle-core"
 version = "0.10.1"
-source = "git+https://github.com/spiceai/candle.git?rev=6ee27a4d621a3470cbf83596722c16de7cf97f12#6ee27a4d621a3470cbf83596722c16de7cf97f12"
+source = "git+https://github.com/spiceai/candle.git?rev=37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4#37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4"
 dependencies = [
  "accelerate-src",
  "byteorder",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.10.1"
-source = "git+https://github.com/spiceai/candle.git?rev=6ee27a4d621a3470cbf83596722c16de7cf97f12#6ee27a4d621a3470cbf83596722c16de7cf97f12"
+source = "git+https://github.com/spiceai/candle.git?rev=37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4#37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -677,7 +677,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn-v3"
 version = "0.10.1"
-source = "git+https://github.com/spiceai/candle.git?rev=6ee27a4d621a3470cbf83596722c16de7cf97f12#6ee27a4d621a3470cbf83596722c16de7cf97f12"
+source = "git+https://github.com/spiceai/candle.git?rev=37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4#37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -690,7 +690,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.10.1"
-source = "git+https://github.com/spiceai/candle.git?rev=6ee27a4d621a3470cbf83596722c16de7cf97f12#6ee27a4d621a3470cbf83596722c16de7cf97f12"
+source = "git+https://github.com/spiceai/candle.git?rev=37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4#37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4"
 dependencies = [
  "cudaforge",
 ]
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.10.1"
-source = "git+https://github.com/spiceai/candle.git?rev=6ee27a4d621a3470cbf83596722c16de7cf97f12#6ee27a4d621a3470cbf83596722c16de7cf97f12"
+source = "git+https://github.com/spiceai/candle.git?rev=37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4#37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4"
 dependencies = [
  "half",
  "objc2",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.10.1"
-source = "git+https://github.com/spiceai/candle.git?rev=6ee27a4d621a3470cbf83596722c16de7cf97f12#6ee27a4d621a3470cbf83596722c16de7cf97f12"
+source = "git+https://github.com/spiceai/candle.git?rev=37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4#37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4"
 dependencies = [
  "accelerate-src",
  "candle-core",
@@ -731,7 +731,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.10.1"
-source = "git+https://github.com/spiceai/candle.git?rev=6ee27a4d621a3470cbf83596722c16de7cf97f12#6ee27a4d621a3470cbf83596722c16de7cf97f12"
+source = "git+https://github.com/spiceai/candle.git?rev=37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4#37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ license = "MIT"
 rust-version = "1.88"
 
 [workspace.dependencies]
-candle-core = { git = "https://github.com/spiceai/candle.git", rev = "6ee27a4d621a3470cbf83596722c16de7cf97f12" }
-candle-nn = { git = "https://github.com/spiceai/candle.git", rev = "6ee27a4d621a3470cbf83596722c16de7cf97f12" }
-candle-flash-attn-v3 = { git = "https://github.com/spiceai/candle.git", rev = "6ee27a4d621a3470cbf83596722c16de7cf97f12" }
-candle-flash-attn = { git = "https://github.com/spiceai/candle.git", rev = "6ee27a4d621a3470cbf83596722c16de7cf97f12" }
-candle-metal-kernels = { git = "https://github.com/spiceai/candle.git", rev = "6ee27a4d621a3470cbf83596722c16de7cf97f12" }
+candle-core = { git = "https://github.com/spiceai/candle.git", rev = "37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4" }
+candle-nn = { git = "https://github.com/spiceai/candle.git", rev = "37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4" }
+candle-flash-attn-v3 = { git = "https://github.com/spiceai/candle.git", rev = "37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4" }
+candle-flash-attn = { git = "https://github.com/spiceai/candle.git", rev = "37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4" }
+candle-metal-kernels = { git = "https://github.com/spiceai/candle.git", rev = "37db2e16bbd1945dab9f8a4fc872cbf0b255d6b4" }
 # candle-core = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.3", rev = "88ed791" }
 # candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.3", rev = "88ed791" }
 # candle-flash-attn-v3 = { git = "https://github.com/huggingface/candle.git", version = "0.9.2-alpha.3", rev = "88ed791" }

--- a/mistralrs-core/src/gguf/glm_moe.rs
+++ b/mistralrs-core/src/gguf/glm_moe.rs
@@ -1,0 +1,632 @@
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+//! GGUF loader + dense forward for GLM-4.x / GLM-5.2 MoE models whose
+//! `general.architecture == "glm-dsa"`.
+//!
+//! `glm-dsa` is structurally DeepSeek-V3: Multi-head Latent Attention (MLA) with a
+//! LoRA-compressed Q/KV path, plus a sigmoid-gated MoE FFN with a shared expert and
+//! a routing-bias correction term. It additionally carries a DeepSeek-Sparse-Attention
+//! (DSA) "lightning indexer" and an MTP (next-n) head.
+//!
+//! This implementation runs attention **DENSE** (full softmax SDPA over the
+//! reconstructed K/V): the DSA sparse-attention indexer is not implemented anywhere in
+//! this codebase, and llama.cpp also evaluates this model with dense attention. The
+//! per-layer `indexer.*` tensors and the `nextn.*` (MTP) tensors are therefore loaded
+//! by name but intentionally skipped — they are not consumed by the dense forward.
+//!
+//! Structure mirrors `models::quantized_qwen3_moe` (GGUF reading idioms, `GgufMatMul`,
+//! the block loop, KV cache) and `models::deepseek3` (the MLA attention forward and the
+//! sigmoid/bias/group MoE gate). Routed experts are built as [`GgufMatMul`] and run
+//! through `QuantMethod::gather_forward`, so i-quant expert dtypes (IQ1_S / IQ1_M /
+//! IQ2_XXS / IQ3_XXS / IQ4_XS) flow through the i-quant gather fallback in
+//! `mistralrs-quant/src/gguf/cuda.rs` (dequantize-per-expert), rather than candle's
+//! fused `QMatMul::indexed_moe_forward` (which has no i-quant kernel).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::attention::{AttentionMask, SdpaParams};
+use crate::device_map::{DeviceMappedMask, DeviceMapper};
+use crate::gguf::Content;
+use crate::layers::{CausalMaskConfig, CausalMasker, QRmsNorm, RotaryEmbedding, Sdpa};
+use crate::layers_masker::PastKvLenCache;
+use crate::ops::TopKLastDimOp;
+use crate::paged_attention::AttentionImplementation;
+use crate::pipeline::text_models_inputs_processor::PagedAttentionInputMetadata;
+use crate::pipeline::{extract_logits, EitherCache, KvCache, NormalCache};
+use crate::utils::gguf_metadata::ContentMetadata;
+use crate::utils::model_config as ModelConfig;
+use crate::utils::progress::{new_multi_progress, NiceProgressBar};
+use candle_core::{DType, Device, Result, Tensor, D};
+use candle_nn::{Embedding, Module};
+use mistralrs_quant::{GgufMatMul, QuantMethod, QuantMethodConfig};
+
+// Default fallback for models that don't specify context_length.
+const DEFAULT_MAX_SEQ_LEN: u32 = 4096;
+
+fn gguf_linear(qt: candle_core::quantized::QTensor) -> Result<Arc<dyn QuantMethod>> {
+    Ok(Arc::new(GgufMatMul::new(QuantMethodConfig::Gguf {
+        q_weight: Arc::new(qt),
+        b: None,
+    })?))
+}
+
+/// Standard dense SwiGLU MLP (leading dense layers + the MoE shared expert).
+struct Mlp {
+    gate: Arc<dyn QuantMethod>,
+    up: Arc<dyn QuantMethod>,
+    down: Arc<dyn QuantMethod>,
+}
+
+impl Mlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let gate = self.gate.forward(xs)?;
+        let up = self.up.forward(xs)?;
+        let y = crate::ops::mul_and_act(&gate, &up, crate::layers::Activation::Silu)?;
+        self.down.forward(&y)
+    }
+}
+
+/// Sigmoid-gated, bias-corrected top-k router (DeepSeek-V3 / GLM-MoE "noaux_tc").
+///
+/// `expert_group_count == 1` for this model, so the group-limited routing reduces to a
+/// plain top-k over all experts; the group machinery is therefore a no-op and omitted.
+struct MoeGate {
+    weight: Tensor,                  // [n_experts, hidden] f32
+    e_score_correction_bias: Tensor, // [n_experts] f32
+    top_k: usize,
+    weights_norm: bool,
+    weights_scale: f64,
+}
+
+impl MoeGate {
+    /// Returns `(topk_idx [n, top_k], topk_weight [n, top_k])`.
+    fn forward(&self, xs: &Tensor) -> Result<(Tensor, Tensor)> {
+        let (_bs, _seq_len, h) = xs.dims3()?;
+        let xs = xs.reshape(((), h))?;
+        let logits = xs
+            .to_dtype(DType::F32)?
+            .broadcast_matmul(&self.weight.t()?)?;
+        let scores = candle_nn::ops::sigmoid(&logits)?;
+
+        // Selection uses scores + correction bias; the returned weights use raw scores.
+        let scores_for_choice = scores.broadcast_add(&self.e_score_correction_bias.unsqueeze(0)?)?;
+        let topk_idx = scores_for_choice.topk(self.top_k)?.indices;
+        let mut topk_weight = scores.gather(&topk_idx, 1)?;
+
+        if self.weights_norm {
+            let denom = (topk_weight.sum_keepdim(D::Minus1)? + 1e-20)?;
+            topk_weight = topk_weight.broadcast_div(&denom)?;
+        }
+        topk_weight = (topk_weight * self.weights_scale)?;
+        Ok((topk_idx, topk_weight))
+    }
+}
+
+/// Routed MoE: top-k experts (i-quant-capable gather) + a single shared expert.
+struct Moe {
+    gate: MoeGate,
+    gate_experts: Arc<dyn QuantMethod>,
+    up_experts: Arc<dyn QuantMethod>,
+    down_experts: Arc<dyn QuantMethod>,
+    shared: Mlp,
+}
+
+impl Moe {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let (bs, seq_len, hidden) = xs.dims3()?;
+        let identity = xs.clone();
+
+        let (topk_idx, topk_weight) = self.gate.forward(xs)?;
+
+        let num_tokens = bs * seq_len;
+        let xs_flat = xs.reshape((num_tokens, 1, hidden))?;
+
+        // gather_forward -> qmatmul_indexed_moe_forward (i-quant fallback lives there).
+        let gate = self.gate_experts.gather_forward(&xs_flat, &topk_idx)?;
+        let up = self.up_experts.gather_forward(&xs_flat, &topk_idx)?;
+        let activated = crate::ops::mul_and_act(&gate, &up, crate::layers::Activation::Silu)?;
+        let ys = self.down_experts.gather_forward(&activated, &topk_idx)?;
+
+        // Weight by routing scores and sum over the selected experts.
+        let topk_weight = topk_weight.to_dtype(ys.dtype())?;
+        let routed = ys
+            .broadcast_mul(&topk_weight.unsqueeze(D::Minus1)?)?
+            .sum(D::Minus2)?
+            .reshape((bs, seq_len, hidden))?;
+
+        routed + self.shared.forward(&identity)?
+    }
+}
+
+enum MoeOrMlp {
+    Moe(Box<Moe>),
+    Mlp(Mlp),
+}
+
+impl MoeOrMlp {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Mlp(m) => m.forward(xs),
+            Self::Moe(m) => m.forward(xs),
+        }
+    }
+}
+
+/// MLA attention weights for one layer, evaluated dense.
+struct LayerWeights {
+    // Q path: down-proj -> RMSNorm -> up-proj.
+    q_a_proj: Arc<dyn QuantMethod>,
+    q_a_norm: QRmsNorm,
+    q_b_proj: Arc<dyn QuantMethod>,
+    // KV path: down-proj (to kv_lora + rope) -> RMSNorm on the kv_lora part.
+    kv_a_proj_with_mqa: Arc<dyn QuantMethod>,
+    kv_a_norm: QRmsNorm,
+    // Latent K/V up-projections, per head, dequantized to f32 at load.
+    // k_b: [n_head, kv_lora, qk_nope]   (k_nope = ckv @ k_b[h])
+    // v_b_t: [n_head, kv_lora, v_head]  (v      = ckv @ v_b_t[h])
+    k_b: Tensor,
+    v_b_t: Tensor,
+    o_proj: Arc<dyn QuantMethod>,
+
+    attn_norm: QRmsNorm,
+    ffn_norm: QRmsNorm,
+    mlp: MoeOrMlp,
+
+    rotary: Arc<RotaryEmbedding>,
+    n_head: usize,
+    kv_lora_rank: usize,
+    qk_nope_head_dim: usize,
+    qk_rope_head_dim: usize,
+    #[allow(dead_code)]
+    v_head_dim: usize,
+    sdpa_params: SdpaParams,
+    dtype: DType,
+}
+
+impl LayerWeights {
+    fn forward_attn(
+        &self,
+        x: &Tensor,
+        mask: &AttentionMask,
+        start_offsets: &[usize],
+        kv_cache: &mut KvCache,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, _) = x.dims3()?;
+        let q_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim;
+
+        // --- Query: x -> q_a -> norm -> q_b -> [b, n_head, s, q_head_dim] ---
+        let q = self.q_b_proj.forward(&self.q_a_norm.forward(&self.q_a_proj.forward(x)?)?)?;
+        let q = q
+            .reshape((b_sz, seq_len, self.n_head, q_head_dim))?
+            .transpose(1, 2)?;
+        let q_nope = q.narrow(D::Minus1, 0, self.qk_nope_head_dim)?;
+        let q_pe = q.narrow(D::Minus1, self.qk_nope_head_dim, self.qk_rope_head_dim)?;
+
+        // --- Compressed KV: x -> kv_a_mqa -> split(kv_lora, rope) ---
+        let compressed = self.kv_a_proj_with_mqa.forward(x)?;
+        let ckv = compressed.narrow(D::Minus1, 0, self.kv_lora_rank)?;
+        let k_pe = compressed.narrow(D::Minus1, self.kv_lora_rank, self.qk_rope_head_dim)?;
+        let k_pe = k_pe
+            .reshape((b_sz, seq_len, 1, self.qk_rope_head_dim))?
+            .transpose(1, 2)?; // [b, 1, s, rope]
+        let ckv = self.kv_a_norm.forward(&ckv)?; // [b, s, kv_lora]
+
+        // --- RoPE (NeoX / rotate-half) on the rope slices only ---
+        let (q_pe, k_pe) = self.rotary.forward(&q_pe.contiguous()?, &k_pe, start_offsets)?;
+
+        // --- Reconstruct per-head K_nope and V from the latent (dense MLA) ---
+        // ckv: [b, s, kv_lora] -> [b, 1, s, kv_lora] to broadcast against [1, n_head, kv_lora, *]
+        let ckv_b = ckv.reshape((b_sz, 1, seq_len, self.kv_lora_rank))?;
+        let k_b = self.k_b.to_dtype(ckv_b.dtype())?.unsqueeze(0)?; // [1, n_head, kv_lora, qk_nope]
+        let v_b_t = self.v_b_t.to_dtype(ckv_b.dtype())?.unsqueeze(0)?; // [1, n_head, kv_lora, v_head]
+        let k_nope = ckv_b.broadcast_matmul(&k_b)?; // [b, n_head, s, qk_nope]
+        let v = ckv_b.broadcast_matmul(&v_b_t)?; // [b, n_head, s, v_head]
+
+        // --- Assemble full Q, K (broadcast k_pe across heads) ---
+        let q = Tensor::cat(&[&q_nope, &q_pe], D::Minus1)?.contiguous()?; // [b, n_head, s, q_head_dim]
+        let k_pe_full = k_pe.broadcast_as((b_sz, self.n_head, seq_len, self.qk_rope_head_dim))?;
+        let k = Tensor::cat(&[&k_nope, &k_pe_full], D::Minus1)?.contiguous()?; // [b, n_head, s, q_head_dim]
+
+        let (q, k, v) = (
+            q.to_dtype(self.dtype)?,
+            k.to_dtype(self.dtype)?,
+            v.to_dtype(self.dtype)?,
+        );
+
+        // Dense KV cache + full SDPA. v_head_dim (256) == q_head_dim (256) here, so the
+        // standard NormalCache layout is fine.
+        let (k, v) = kv_cache.append(&k, &v)?;
+        let y = Sdpa.run_attention(&q, &k, &v, mask, None, &self.sdpa_params)?;
+
+        let y = if mask.is_custom() {
+            y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?
+        } else {
+            y.reshape((b_sz, seq_len, ()))?
+        };
+        self.o_proj.forward(&y.to_dtype(x.dtype())?)
+    }
+}
+
+pub struct ModelWeights {
+    tok_embeddings: Embedding,
+    layers: Vec<LayerWeights>,
+    norm: QRmsNorm,
+    output: Arc<dyn QuantMethod>,
+    pub device: Device,
+    pub cache: EitherCache,
+    pub max_seq_len: usize,
+    mapper: Option<Box<dyn DeviceMapper + Send + Sync>>,
+    dtype: DType,
+}
+
+pub(crate) struct PropsGGUF {
+    head_count: usize,
+    block_count: usize,
+    embedding_length: usize,
+    rms_norm_eps: f32,
+    max_seq_len: usize,
+    rope_freq_base: f32,
+    rope_dim: usize,
+    q_lora_rank: usize,
+    kv_lora_rank: usize,
+    qk_nope_head_dim: usize,
+    qk_rope_head_dim: usize,
+    v_head_dim: usize,
+    // MoE
+    leading_dense_block_count: usize,
+    expert_used_count: usize,
+    expert_weights_norm: bool,
+    expert_weights_scale: f64,
+}
+
+fn verify_glm_dsa_arch(
+    metadata: &HashMap<String, candle_core::quantized::gguf_file::Value>,
+) -> Result<()> {
+    use crate::utils::gguf_metadata::TryValueInto;
+    let arch: String = metadata
+        .get("general.architecture")
+        .cloned()
+        .try_value_into()?;
+    if arch != "glm-dsa" {
+        candle_core::bail!("Expected `glm-dsa` architecture, got `{arch}`.");
+    }
+    Ok(())
+}
+
+impl TryFrom<ContentMetadata<'_>> for PropsGGUF {
+    type Error = anyhow::Error;
+
+    fn try_from(c: ContentMetadata) -> std::result::Result<Self, Self::Error> {
+        let required = [
+            "attention.head_count",
+            "block_count",
+            "embedding_length",
+            "attention.layer_norm_rms_epsilon",
+            "attention.q_lora_rank",
+            "attention.kv_lora_rank",
+            "rope.dimension_count",
+            "expert_count",
+            "expert_used_count",
+        ];
+        c.has_required_keys(&required)?;
+
+        // q_head_dim = key_length (576) is kv_lora + rope for the *compressed* path; the
+        // *decompressed* per-head q/k dim is qk_nope + qk_rope. From the GGUF:
+        //   key_length_mla = 256 = qk_nope + qk_rope (per-head decompressed)
+        //   rope.dimension_count = qk_rope_head_dim
+        //   value_length_mla = 256 = v_head_dim
+        let rope_dim = c.get_value::<u32>("rope.dimension_count")? as usize;
+        let per_head_qk = c
+            .get_value::<u32>("attention.key_length_mla")
+            .map(|x| x as usize)
+            .unwrap_or(256);
+        let v_head_dim = c
+            .get_value::<u32>("attention.value_length_mla")
+            .map(|x| x as usize)
+            .unwrap_or(256);
+
+        Ok(Self {
+            head_count: c.get_value::<u32>("attention.head_count")? as usize,
+            block_count: c.get_value::<u32>("block_count")? as usize,
+            embedding_length: c.get_value::<u32>("embedding_length")? as usize,
+            rms_norm_eps: c.get_value("attention.layer_norm_rms_epsilon")?,
+            max_seq_len: c
+                .get_value::<u64>("context_length")
+                .ok()
+                .unwrap_or(DEFAULT_MAX_SEQ_LEN as u64) as usize,
+            rope_freq_base: c.get_value("rope.freq_base").ok().unwrap_or(10_000_f32),
+            rope_dim,
+            q_lora_rank: c.get_value::<u32>("attention.q_lora_rank")? as usize,
+            kv_lora_rank: c.get_value::<u32>("attention.kv_lora_rank")? as usize,
+            qk_rope_head_dim: rope_dim,
+            qk_nope_head_dim: per_head_qk - rope_dim,
+            v_head_dim,
+            leading_dense_block_count: c
+                .get_value::<u32>("leading_dense_block_count")
+                .map(|x| x as usize)
+                .unwrap_or(0),
+            expert_used_count: c.get_value::<u32>("expert_used_count")? as usize,
+            expert_weights_norm: c.get_value::<bool>("expert_weights_norm").unwrap_or(true),
+            expert_weights_scale: c
+                .get_value::<f32>("expert_weights_scale")
+                .map(|x| x as f64)
+                .unwrap_or(1.0),
+        })
+    }
+}
+
+impl ModelConfig::FromGGUF for ModelWeights {
+    fn from_gguf<R: std::io::Seek + std::io::Read>(
+        mut ct: Content<'_, R>,
+        device: &Device,
+        mapper: Box<dyn DeviceMapper + Send + Sync>,
+        attention_mechanism: AttentionImplementation,
+        dtype: DType,
+    ) -> Result<Self> {
+        let meta = ct.get_metadata();
+        verify_glm_dsa_arch(meta)?;
+
+        if !matches!(attention_mechanism, AttentionImplementation::Eager) {
+            candle_core::bail!(
+                "glm-dsa GGUF currently supports only dense (Eager) attention; PagedAttention/MLA is not implemented."
+            );
+        }
+
+        let metadata = ContentMetadata {
+            path_prefix: "glm-dsa",
+            metadata: meta,
+        };
+        let PropsGGUF {
+            head_count,
+            block_count,
+            embedding_length,
+            rms_norm_eps,
+            max_seq_len,
+            rope_freq_base,
+            rope_dim,
+            q_lora_rank: _q_lora_rank,
+            kv_lora_rank,
+            qk_nope_head_dim,
+            qk_rope_head_dim,
+            v_head_dim,
+            leading_dense_block_count,
+            expert_used_count,
+            expert_weights_norm,
+            expert_weights_scale,
+        } = PropsGGUF::try_from(metadata).or_else(|err| candle_core::bail!("{err}"))?;
+
+        let q_head_dim = qk_nope_head_dim + qk_rope_head_dim;
+
+        let tok_embeddings = ct.tensor("token_embd.weight", device)?.dequantize(device)?;
+        let norm = QRmsNorm::new(ct.tensor("output_norm.weight", device)?, rms_norm_eps)?;
+        let output = if ct.has_tensor("output.weight") {
+            ct.tensor("output.weight", device)?
+        } else {
+            ct.tensor("token_embd.weight", device)?
+        };
+
+        // RoPE: NeoX (rotate-half) — llama.cpp evaluates deepseek2/glm with
+        // LLAMA_ROPE_TYPE_NEOX and the GGUF weights are not pre-permuted.
+        let mut ropes = HashMap::new();
+        for layer_idx in 0..block_count {
+            let device = mapper.device_for(layer_idx, false).unwrap_or(device);
+            ropes.insert(
+                device.location(),
+                Arc::new(RotaryEmbedding::new(
+                    rope_freq_base,
+                    rope_dim,
+                    max_seq_len,
+                    device,
+                    /* is_gpt_neox = */ true,
+                    DType::F32,
+                )?),
+            );
+        }
+
+        let mut layers = Vec::with_capacity(block_count);
+        for layer_idx in NiceProgressBar::<_, 'b'>(
+            0..block_count,
+            "Loading repeating layers",
+            &new_multi_progress(),
+        ) {
+            let prefix = format!("blk.{layer_idx}");
+            let device = mapper.device_for(layer_idx, false).unwrap_or(device);
+            let rotary = ropes
+                .get(&device.location())
+                .expect("No RoPE for device location!")
+                .clone();
+
+            // --- Attention (MLA) ---
+            let q_a_proj = gguf_linear(ct.tensor(&format!("{prefix}.attn_q_a.weight"), device)?)?;
+            let q_a_norm = QRmsNorm::new(
+                ct.tensor(&format!("{prefix}.attn_q_a_norm.weight"), device)?,
+                rms_norm_eps,
+            )?;
+            let q_b_proj = gguf_linear(ct.tensor(&format!("{prefix}.attn_q_b.weight"), device)?)?;
+            let kv_a_proj_with_mqa =
+                gguf_linear(ct.tensor(&format!("{prefix}.attn_kv_a_mqa.weight"), device)?)?;
+            let kv_a_norm = QRmsNorm::new(
+                ct.tensor(&format!("{prefix}.attn_kv_a_norm.weight"), device)?,
+                rms_norm_eps,
+            )?;
+
+            // Latent up-projections. Dequantize to f32 (Q8_0, small) and normalize layout to
+            // [n_head, kv_lora, *] so K_nope/V = ckv @ W per head.
+            //   k_b GGUF candle dims = [n_head, kv_lora, qk_nope] (already [h, kv_lora, qk_nope]).
+            //   v_b GGUF candle dims = [n_head, v_head, kv_lora]  -> transpose last two to [h, kv_lora, v_head].
+            let k_b = ct
+                .tensor(&format!("{prefix}.attn_k_b.weight"), device)?
+                .dequantize(device)?;
+            let v_b = ct
+                .tensor(&format!("{prefix}.attn_v_b.weight"), device)?
+                .dequantize(device)?;
+            // Validate the assumed layout against the metadata-derived dims.
+            {
+                let kd = k_b.dims();
+                if kd != [head_count, kv_lora_rank, qk_nope_head_dim] {
+                    candle_core::bail!(
+                        "attn_k_b dims {kd:?} != expected [{head_count}, {kv_lora_rank}, {qk_nope_head_dim}]"
+                    );
+                }
+                let vd = v_b.dims();
+                if vd != [head_count, v_head_dim, kv_lora_rank] {
+                    candle_core::bail!(
+                        "attn_v_b dims {vd:?} != expected [{head_count}, {v_head_dim}, {kv_lora_rank}]"
+                    );
+                }
+            }
+            let v_b_t = v_b.transpose(1, 2)?.contiguous()?; // [n_head, kv_lora, v_head]
+
+            let o_proj =
+                gguf_linear(ct.tensor(&format!("{prefix}.attn_output.weight"), device)?)?;
+
+            // --- FFN: leading dense layers vs MoE layers ---
+            let mlp = if layer_idx < leading_dense_block_count {
+                MoeOrMlp::Mlp(Mlp {
+                    gate: gguf_linear(ct.tensor(&format!("{prefix}.ffn_gate.weight"), device)?)?,
+                    up: gguf_linear(ct.tensor(&format!("{prefix}.ffn_up.weight"), device)?)?,
+                    down: gguf_linear(ct.tensor(&format!("{prefix}.ffn_down.weight"), device)?)?,
+                })
+            } else {
+                let gate_inp = ct
+                    .tensor(&format!("{prefix}.ffn_gate_inp.weight"), device)?
+                    .dequantize(device)?
+                    .to_dtype(DType::F32)?;
+                let e_score_correction_bias = ct
+                    .tensor(&format!("{prefix}.exp_probs_b.bias"), device)?
+                    .dequantize(device)?
+                    .to_dtype(DType::F32)?;
+                let gate = MoeGate {
+                    weight: gate_inp,
+                    e_score_correction_bias,
+                    top_k: expert_used_count,
+                    weights_norm: expert_weights_norm,
+                    weights_scale: expert_weights_scale,
+                };
+                let gate_experts =
+                    gguf_linear(ct.tensor(&format!("{prefix}.ffn_gate_exps.weight"), device)?)?;
+                let up_experts =
+                    gguf_linear(ct.tensor(&format!("{prefix}.ffn_up_exps.weight"), device)?)?;
+                let down_experts =
+                    gguf_linear(ct.tensor(&format!("{prefix}.ffn_down_exps.weight"), device)?)?;
+                let shared = Mlp {
+                    gate: gguf_linear(
+                        ct.tensor(&format!("{prefix}.ffn_gate_shexp.weight"), device)?,
+                    )?,
+                    up: gguf_linear(ct.tensor(&format!("{prefix}.ffn_up_shexp.weight"), device)?)?,
+                    down: gguf_linear(
+                        ct.tensor(&format!("{prefix}.ffn_down_shexp.weight"), device)?,
+                    )?,
+                };
+                MoeOrMlp::Moe(Box::new(Moe {
+                    gate,
+                    gate_experts,
+                    up_experts,
+                    down_experts,
+                    shared,
+                }))
+            };
+
+            let attn_norm = QRmsNorm::new(
+                ct.tensor(&format!("{prefix}.attn_norm.weight"), device)?,
+                rms_norm_eps,
+            )?;
+            let ffn_norm = QRmsNorm::new(
+                ct.tensor(&format!("{prefix}.ffn_norm.weight"), device)?,
+                rms_norm_eps,
+            )?;
+
+            // NOTE: `blk.N.indexer.*` (DSA lightning indexer) and `blk.{last}.nextn.*`
+            // (MTP head) tensors are intentionally NOT read — dense attention does not use
+            // them. See module docs / the coverage report.
+
+            layers.push(LayerWeights {
+                q_a_proj,
+                q_a_norm,
+                q_b_proj,
+                kv_a_proj_with_mqa,
+                kv_a_norm,
+                k_b,
+                v_b_t,
+                o_proj,
+                attn_norm,
+                ffn_norm,
+                mlp,
+                rotary: rotary.clone(),
+                n_head: head_count,
+                kv_lora_rank,
+                qk_nope_head_dim,
+                qk_rope_head_dim,
+                v_head_dim,
+                sdpa_params: SdpaParams {
+                    n_kv_groups: 1,
+                    softcap: None,
+                    softmax_scale: 1.0 / (q_head_dim as f32).sqrt(),
+                    sliding_window: None,
+                    sinks: None,
+                },
+                dtype,
+            });
+        }
+
+        Ok(Self {
+            tok_embeddings: Embedding::new(tok_embeddings, embedding_length),
+            layers,
+            norm,
+            output: gguf_linear(output)?,
+            device: device.clone(),
+            cache: EitherCache::Normal(NormalCache::new(block_count, max_seq_len)),
+            max_seq_len,
+            mapper: Some(mapper),
+            dtype,
+        })
+    }
+}
+
+impl ModelWeights {
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        start_offsets: &[usize],
+        context_lens: Vec<(usize, usize)>,
+        _metadata: Option<(Vec<(Tensor, Tensor)>, &PagedAttentionInputMetadata)>,
+    ) -> Result<Tensor> {
+        let mut layer_in = self.tok_embeddings.forward(x)?;
+        let cache = &mut self.cache.normal().0;
+        let mask = CausalMasker.make_causal_mask(
+            x,
+            cache as &dyn PastKvLenCache,
+            self.dtype,
+            &CausalMaskConfig::default(),
+        )?;
+        let mask = if let Some(ref mapper) = self.mapper {
+            DeviceMappedMask::new(mask, &**mapper)?
+        } else {
+            DeviceMappedMask::from_single(mask)
+        };
+        for (i, layer) in self.layers.iter().enumerate() {
+            if let Some(ref mapper) = self.mapper {
+                layer_in = mapper.map(layer_in, i)?;
+            }
+            let x = layer_in;
+            let residual = &x;
+            let x_normed = layer.attn_norm.forward(&x)?;
+            let attn = layer.forward_attn(
+                &x_normed,
+                &mask.get(x_normed.device()),
+                start_offsets,
+                &mut cache[i],
+            )?;
+            let x = (attn + residual)?;
+
+            let residual = &x;
+            let x_normed = layer.ffn_norm.forward(&x)?;
+            let x = (layer.mlp.forward(&x_normed)? + residual)?;
+            layer_in = x;
+        }
+        let x = self.norm.forward(&layer_in)?;
+        let x = extract_logits(&x, context_lens)?;
+        self.output.forward(&x.contiguous()?)
+    }
+}

--- a/mistralrs-core/src/gguf/mod.rs
+++ b/mistralrs-core/src/gguf/mod.rs
@@ -1,4 +1,5 @@
 mod chat_template;
+pub(crate) mod glm_moe;
 mod content;
 mod gguf_tokenizer;
 use strum::EnumString;
@@ -30,6 +31,8 @@ pub enum GGUFArchitecture {
     Qwen3,
     Qwen3MoE,
     Mistral3,
+    #[strum(serialize = "glm-dsa")]
+    GlmDsa,
 }
 
 // Wraps from_str() for some convenience:

--- a/mistralrs-core/src/moe/experts.rs
+++ b/mistralrs-core/src/moe/experts.rs
@@ -19,6 +19,21 @@ use crate::cuda::moe;
 use crate::layers::Activation;
 use crate::moe::shard;
 
+/// i-quant GGUF dtypes have no fused CUDA MoE kernel, so the fast decode/grouped
+/// paths must fall back to the generic gather path (which dequantizes per-expert).
+#[cfg(feature = "cuda")]
+fn is_iquant_dtype(dtype: candle_core::quantized::GgmlDType) -> bool {
+    use candle_core::quantized::GgmlDType;
+    matches!(
+        dtype,
+        GgmlDType::Iq2Xxs
+            | GgmlDType::Iq3Xxs
+            | GgmlDType::Iq4Xs
+            | GgmlDType::Iq1S
+            | GgmlDType::Iq1M
+    )
+}
+
 /// Configuration for MoEExperts
 pub struct MoEExpertsConfig {
     pub num_experts: usize,
@@ -918,6 +933,15 @@ impl MoEExperts {
             None => return Ok(None),
         };
 
+        // i-quants have no fused-decode kernel; fall back to the generic gather
+        // path (which dequantizes per-expert to f32). See gguf/cuda.rs.
+        if is_iquant_dtype(gate_qt.dtype())
+            || is_iquant_dtype(up_qt.dtype())
+            || is_iquant_dtype(down_qt.dtype())
+        {
+            return Ok(None);
+        }
+
         // Get topk_ids as contiguous u32 CudaSlice
         let topk_ids_flat = topk_ids.flatten_all()?.contiguous()?;
         let (ti_storage, ti_layout) = topk_ids_flat.storage_and_layout();
@@ -1018,6 +1042,15 @@ impl MoEExperts {
             Some(qt) => qt,
             None => return Ok(None),
         };
+
+        // i-quants have no grouped-prefill kernel; fall back to the generic gather
+        // path (which dequantizes per-expert to f32). See gguf/cuda.rs.
+        if is_iquant_dtype(gate_qt.dtype())
+            || is_iquant_dtype(up_qt.dtype())
+            || is_iquant_dtype(down_qt.dtype())
+        {
+            return Ok(None);
+        }
 
         // Quantize input to Q8_1 ONCE, shared between gate and up.
         // quantize_input_q8_1 accepts BF16/F16/F32 directly (no conversion needed).

--- a/mistralrs-core/src/pipeline/gguf.rs
+++ b/mistralrs-core/src/pipeline/gguf.rs
@@ -14,6 +14,7 @@ use crate::distributed::WorkerTransferData;
 use crate::gguf::{
     get_gguf_chat_template, {convert_gguf_to_hf_tokenizer, GgufTokenizerConversion},
 };
+use crate::gguf::glm_moe::ModelWeights as QGlmDsa;
 use crate::gguf::{Content, GGUFArchitecture};
 use crate::kv_cache::{FullCacheManager, NormalCacheManager};
 use crate::lora::Ordering;
@@ -72,6 +73,7 @@ enum Model {
     Qwen(QQwen),
     Qwen3(QQwen3),
     Qwen3MoE(QQwen3MoE),
+    GlmDsa(QGlmDsa),
 }
 
 pub struct GGUFPipeline {
@@ -483,6 +485,7 @@ impl Loader for GGUFLoader {
                 GGUFArchitecture::Qwen2 => Model::Qwen(QQwen::try_from(model_config)?),
                 GGUFArchitecture::Qwen3 => Model::Qwen3(QQwen3::try_from(model_config)?),
                 GGUFArchitecture::Qwen3MoE => Model::Qwen3MoE(QQwen3MoE::try_from(model_config)?),
+                GGUFArchitecture::GlmDsa => Model::GlmDsa(QGlmDsa::try_from(model_config)?),
                 a => bail!("Unsupported architecture `{a:?}` for GGUF"),
             },
             ModelKind::GgufAdapter { adapter, .. } => match arch {
@@ -549,6 +552,7 @@ impl Loader for GGUFLoader {
             Model::Qwen(ref p) => p.max_seq_len,
             Model::Qwen3(ref p) => p.max_seq_len,
             Model::Qwen3MoE(ref p) => p.max_seq_len,
+            Model::GlmDsa(ref p) => p.max_seq_len,
         };
         let llg_factory = build_llg_factory(tokenizer.clone())?;
         let num_hidden_layers = match model {
@@ -561,6 +565,7 @@ impl Loader for GGUFLoader {
             Model::Qwen(ref model) => model.cache.normal().0.len(),
             Model::Qwen3(ref model) => model.cache.normal().0.len(),
             Model::Qwen3MoE(ref model) => model.cache.normal().0.len(),
+            Model::GlmDsa(ref model) => model.cache.normal().0.len(),
         };
 
         if chat_template.bos_token.is_none() {
@@ -698,6 +703,7 @@ impl CacheManagerMixin for GGUFPipeline {
             Model::Qwen(ref model) => &model.cache,
             Model::Qwen3(ref model) => &model.cache,
             Model::Qwen3MoE(ref model) => &model.cache,
+            Model::GlmDsa(ref model) => &model.cache,
         }
     }
 }
@@ -714,6 +720,7 @@ impl MetadataMixin for GGUFPipeline {
             Model::Qwen(ref model) => model.device.clone(),
             Model::Qwen3(ref model) => model.device.clone(),
             Model::Qwen3MoE(ref model) => model.device.clone(),
+            Model::GlmDsa(ref model) => model.device.clone(),
         }
     }
     fn tokenizer(&self) -> Option<Arc<Tokenizer>> {
@@ -812,6 +819,9 @@ impl Pipeline for GGUFPipeline {
                 model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
             }
             Model::Qwen3MoE(ref model) => {
+                model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
+            }
+            Model::GlmDsa(ref model) => {
                 model.forward(&input_ids, &seqlen_offsets, context_lens, paged_attn_meta)?
             }
         };

--- a/mistralrs-core/src/utils/gguf_metadata.rs
+++ b/mistralrs-core/src/utils/gguf_metadata.rs
@@ -362,6 +362,26 @@ impl DeviceMappedModelLoader for GgufDeviceMapLoaderInner<'_, '_> {
                 };
                 token_embd + output_norm + output
             }
+            // GLM-MoE (`glm-dsa`): MLA attention + sigmoid MoE. The non-mapped
+            // (global) tensors are the same trio as the other decoder archs:
+            // token embeddings, the final norm, and the output head (tied to the
+            // embeddings when `output.weight` is absent).
+            GGUFArchitecture::GlmDsa => {
+                let token_embd = tensor_info_size_in_bytes!(
+                    self.model.tensor_info("token_embd.weight")?,
+                    DType::F32
+                );
+                let output_norm = tensor_info_size_in_bytes!(
+                    self.model.tensor_info("output_norm.weight")?,
+                    DType::F32
+                );
+                let output = if !self.model.has_tensor("output.weight") {
+                    tensor_info_size_in_bytes!(self.model.tensor_info("token_embd.weight")?)
+                } else {
+                    tensor_info_size_in_bytes!(self.model.tensor_info("output.weight")?)
+                };
+                token_embd + output_norm + output
+            }
             _ => unimplemented!(),
         };
         Ok(size_in_bytes)
@@ -643,6 +663,128 @@ impl DeviceMappedModelLoader for GgufDeviceMapLoaderInner<'_, '_> {
                     + ffn_up
                     + ffn_down
                     + ffn_gate
+            }
+
+            // GLM-MoE (`glm-dsa`): MLA attention (+ a per-layer sparse-attention
+            // "indexer" sub-block) and a sigmoid MoE FFN. The first
+            // `leading_dense_block_count` (=3) layers are dense and layers >= 3 are
+            // MoE; the surrounding code returns a single per-layer size replicated
+            // `num_layers` times (a uniform estimate). The MoE layers dominate, so
+            // we measure a representative MoE layer (`blk.3`) and replicate it — a
+            // safe over-estimate for device-map memory planning (never undercounts
+            // the large expert tensors). Attention/indexer shapes are identical
+            // across all layers, so only the FFN portion is an over-estimate for
+            // the three dense layers.
+            GGUFArchitecture::GlmDsa => {
+                // First MoE layer (after the leading dense layers).
+                let l = "blk.3";
+
+                // --- MLA attention ---
+                let attn_norm = tensor_info_size_in_bytes!(
+                    self.model.tensor_info(&format!("{l}.attn_norm.weight"))?,
+                    DType::F32
+                );
+                let attn_q_a = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.attn_q_a.weight"))?);
+                let attn_q_a_norm = tensor_info_size_in_bytes!(
+                    self.model.tensor_info(&format!("{l}.attn_q_a_norm.weight"))?,
+                    DType::F32
+                );
+                let attn_q_b = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.attn_q_b.weight"))?);
+                let attn_kv_a_mqa = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.attn_kv_a_mqa.weight"))?);
+                let attn_kv_a_norm = tensor_info_size_in_bytes!(
+                    self.model
+                        .tensor_info(&format!("{l}.attn_kv_a_norm.weight"))?,
+                    DType::F32
+                );
+                let attn_k_b = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.attn_k_b.weight"))?);
+                let attn_v_b = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.attn_v_b.weight"))?);
+                let attn_output = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.attn_output.weight"))?);
+                let attn = attn_norm
+                    + attn_q_a
+                    + attn_q_a_norm
+                    + attn_q_b
+                    + attn_kv_a_mqa
+                    + attn_kv_a_norm
+                    + attn_k_b
+                    + attn_v_b
+                    + attn_output;
+
+                // --- DSA sparse-attention indexer (present on every layer) ---
+                let indexer = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.indexer.attn_k.weight"))?)
+                    + tensor_info_size_in_bytes!(self
+                        .model
+                        .tensor_info(&format!("{l}.indexer.attn_q_b.weight"))?)
+                    + tensor_info_size_in_bytes!(
+                        self.model
+                            .tensor_info(&format!("{l}.indexer.k_norm.weight"))?,
+                        DType::F32
+                    )
+                    + tensor_info_size_in_bytes!(self
+                        .model
+                        .tensor_info(&format!("{l}.indexer.proj.weight"))?);
+
+                // --- MoE FFN: router + 256 routed experts + 1 shared expert ---
+                let ffn_norm = tensor_info_size_in_bytes!(
+                    self.model.tensor_info(&format!("{l}.ffn_norm.weight"))?,
+                    DType::F32
+                );
+                let ffn_gate_inp = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.ffn_gate_inp.weight"))?);
+                // Routed experts: stacked [hidden, ffn, n_expert] tensors.
+                let ffn_gate_exps = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.ffn_gate_exps.weight"))?);
+                let ffn_up_exps = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.ffn_up_exps.weight"))?);
+                let ffn_down_exps = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.ffn_down_exps.weight"))?);
+                // Shared expert (always active).
+                let ffn_gate_shexp = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.ffn_gate_shexp.weight"))?);
+                let ffn_up_shexp = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.ffn_up_shexp.weight"))?);
+                let ffn_down_shexp = tensor_info_size_in_bytes!(self
+                    .model
+                    .tensor_info(&format!("{l}.ffn_down_shexp.weight"))?);
+                let ffn = ffn_norm
+                    + ffn_gate_inp
+                    + ffn_gate_exps
+                    + ffn_up_exps
+                    + ffn_down_exps
+                    + ffn_gate_shexp
+                    + ffn_up_shexp
+                    + ffn_down_shexp;
+
+                // Tensor parallelism: under the ring (or NCCL) backend the linear
+                // layers are sharded across ranks (Column/Row-ParallelLayer split by
+                // world_size), so each rank only holds ~1/world_size of every layer's
+                // weights. The full-model figure above would size the whole model
+                // against a single node's memory and reject the load. Divide by the
+                // global tensor-parallel size; `get_global_tp_size_from_devices`
+                // returns the ring `world_size` when ring is active, the device count
+                // for NCCL, and 1 otherwise (so the single-node estimate is unchanged).
+                let world_size =
+                    mistralrs_quant::distributed::get_global_tp_size_from_devices().unwrap_or(1);
+                (attn + indexer + ffn) / world_size.max(1)
             }
 
             _ => unimplemented!(),

--- a/mistralrs-core/src/utils/model_config.rs
+++ b/mistralrs-core/src/utils/model_config.rs
@@ -301,6 +301,7 @@ use crate::{
     models::quantized_qwen::ModelWeights as QQwen,
     models::quantized_qwen3::ModelWeights as QQwen3,
     models::quantized_qwen3_moe::ModelWeights as QQwen3MoE,
+    gguf::glm_moe::ModelWeights as QGlmDsa,
     models::quantized_starcoder2::ModelWeights as QStarcoder2,
     xlora_models::{XLoraQLlama, XLoraQPhi3},
 };
@@ -325,7 +326,7 @@ impl TryFrom<ModelParams<'_, ParamsGGML>> for XLoraQLlama {
 }
 
 akin! {
-    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen, QQwen3, QQwen3MoE];
+    let &models_gguf = [QLlama, QPhi, QPhi3, QStarcoder2, QQwen, QQwen3, QQwen3MoE, QGlmDsa];
 
     impl<R: std::io::Seek + std::io::Read> TryFrom<ModelParams<'_, ParamsGGUF<'_, R>>> for *models_gguf {
         type Error = candle_core::Error;

--- a/mistralrs-quant/src/gguf/cuda.rs
+++ b/mistralrs-quant/src/gguf/cuda.rs
@@ -336,6 +336,26 @@ fn indexed_moe_forward_fused_q8_1_input(
 pub fn qtensor_indexed_moe_forward(qtensor: &QTensor, x: &Tensor, ids: &Tensor) -> Result<Tensor> {
     let dtype = qtensor.dtype();
 
+    // i-quants have no fused q8_1 indexed-MoE kernel (and no CPU vec_dot), so the
+    // GPU path below cannot run them. Dequantize the expert weights to f32 (via
+    // candle's CPU `to_float` fallback) and use the unquantized gathered matmul.
+    // The weight stays quantized in memory; only this tensor is materialized as a
+    // transient f32 buffer for the call.
+    if matches!(
+        dtype,
+        GgmlDType::Iq2Xxs
+            | GgmlDType::Iq3Xxs
+            | GgmlDType::Iq4Xs
+            | GgmlDType::Iq1S
+            | GgmlDType::Iq1M
+    ) {
+        let weights = qtensor.dequantize(x.device())?;
+        let unquant = <crate::UnquantLinear as crate::QuantMethod>::new(
+            crate::QuantMethodConfig::Unquantized(candle_nn::Linear::new(weights, None)),
+        )?;
+        return crate::QuantMethod::gather_forward(&unquant, x, ids);
+    }
+
     // Check supported dtypes
     if !matches!(
         dtype,

--- a/mistralrs-quant/src/gguf/mod.rs
+++ b/mistralrs-quant/src/gguf/mod.rs
@@ -319,6 +319,11 @@ impl QuantizedSerde for GgufMatMul {
                     GgmlDType::Q5K => 13,
                     GgmlDType::Q6K => 14,
                     GgmlDType::Q8K => 15,
+                    GgmlDType::Iq2Xxs => 16,
+                    GgmlDType::Iq3Xxs => 18,
+                    GgmlDType::Iq1S => 19,
+                    GgmlDType::Iq4Xs => 23,
+                    GgmlDType::Iq1M => 29,
                     // https://github.com/ggerganov/ggml/blob/29d87fc6676e7ed0cdfdec0804b06001d9c2bb44/include/ggml.h#L389
                     GgmlDType::BF16 => 30,
                 };

--- a/mistralrs-quant/src/lib.rs
+++ b/mistralrs-quant/src/lib.rs
@@ -838,6 +838,15 @@ impl TryFrom<GgmlDType> for IsqType {
             GgmlDType::BF16 | GgmlDType::F32 | GgmlDType::F16 => {
                 candle_core::bail!("Expected valid GGML ISQ type.")
             }
+            // i-quants (IQ2_XXS/IQ3_XXS/IQ4_XS/IQ1_S/IQ1_M) are load/dequant-only here;
+            // mistralrs has no i-quant ISQ quantizer, so they are not valid ISQ targets.
+            GgmlDType::Iq2Xxs
+            | GgmlDType::Iq3Xxs
+            | GgmlDType::Iq4Xs
+            | GgmlDType::Iq1S
+            | GgmlDType::Iq1M => {
+                candle_core::bail!("i-quant types are not a valid GGML ISQ target.")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Two additions enabling GLM MoE inference at i-quant sizes:

1. **GLM-MoE GGUF support** (`general.architecture = "glm-dsa"`) — a GGUF loader + dense forward for GLM-4.x / 5.2 MoE models (DeepSeek-V3-style MLA attention run dense over reconstructed K/V; sigmoid-gated, bias-corrected top-k MoE with a shared expert). The DSA lightning-indexer and MTP (`nextn`) tensors are loaded-by-name but intentionally skipped, matching llama.cpp's dense evaluation. Wired through the GGUF enum, pipeline `Model` enum, the `akin!` `FromGGUF` list, and the device-map size estimator.
2. **i-quant MoE fallback** — the fused/grouped CUDA expert kernels have no i-quant support, so `qtensor_indexed_moe_forward` dequantizes i-quant experts (IQ1_S / IQ1_M / IQ2_XXS / IQ3_XXS / IQ4_XS) per-expert to f32 and runs the unquantized gathered matmul; the two fused MoE paths early-return to that gather path. The i-quant dtypes are registered in the GGUF serializer and rejected as ISQ quant targets.

## Dependency

Bumps candle to the spiceai i-quant rev — spiceai/candle#15 (`lukim/iquant-cpu-dequant`) — which adds the CPU dequant these formats need. **That candle PR should land first**, then this rev pin can be refreshed to the merged SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
